### PR TITLE
Fix an "Ambiguous URI empty segment" error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -366,3 +366,5 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 /ConsoleApp1
+/Tests.Okapi/appsettings.json
+/Tests.Okapi/Output

--- a/Apps.Okapi.sln
+++ b/Apps.Okapi.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.8.34330.188
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Apps.Okapi", "Apps.Okapi\Apps.Okapi.csproj", "{EB25604E-8EBA-464E-BEDF-30EA95395AD3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests.Okapi", "Tests.Okapi\Tests.Okapi.csproj", "{6023FD60-EB0B-49D9-91C9-7AB45646BF78}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{EB25604E-8EBA-464E-BEDF-30EA95395AD3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EB25604E-8EBA-464E-BEDF-30EA95395AD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EB25604E-8EBA-464E-BEDF-30EA95395AD3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6023FD60-EB0B-49D9-91C9-7AB45646BF78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6023FD60-EB0B-49D9-91C9-7AB45646BF78}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6023FD60-EB0B-49D9-91C9-7AB45646BF78}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6023FD60-EB0B-49D9-91C9-7AB45646BF78}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Apps.Okapi/Api/OkapiClient.cs
+++ b/Apps.Okapi/Api/OkapiClient.cs
@@ -25,12 +25,29 @@ public class OkapiClient : RestClient
     {
         var baseUrl = creds.Get(CredsNames.Url).Value
             .TrimEnd('/');
-        
+
         var request = new OkapiRequest(new()
         {
             Url = baseUrl + endpoint,
             Method = method
         });
+
+        return await ExecuteRequest(request);
+    }
+
+    public async Task<RestResponse> UploadFile(string endpoint, Method method, FileParameter fileParam,
+        AuthenticationCredentialsProvider[] creds)
+    {
+        var baseUrl = creds.Get(CredsNames.Url).Value
+            .TrimEnd('/');
+
+        var request = new OkapiRequest(new()
+        {
+            Url = baseUrl + endpoint,
+            Method = method
+        });
+
+        request.AddFile(fileParam.Name, () => fileParam.GetFile(), fileParam.FileName, fileParam.ContentType);
 
         return await ExecuteRequest(request);
     }

--- a/Apps.Okapi/Api/OkapiClient.cs
+++ b/Apps.Okapi/Api/OkapiClient.cs
@@ -16,10 +16,10 @@ public class OkapiClient : RestClient
         var serializer = new XmlSerializer(typeof(T));
         using var reader = new StringReader(response.Content);
         var result = (T)serializer.Deserialize(reader)!;
-        
+
         return result;
     }
-    
+
     public async Task<RestResponse> Execute(string endpoint, Method method, object? bodyObj,
         AuthenticationCredentialsProvider[] creds)
     {
@@ -51,7 +51,7 @@ public class OkapiClient : RestClient
 
         return await ExecuteRequest(request);
     }
-    
+
     public async Task<RestResponse> ExecuteRequest(OkapiRequest request)
     {
         var response = await ExecuteAsync(request);
@@ -61,7 +61,7 @@ public class OkapiClient : RestClient
 
         return response;
     }
-    
+
     private Exception GetError(RestResponse response)
     {
           throw new PluginApplicationException($"Status code: {response.StatusCode}, Content: {response.Content}");

--- a/Apps.Okapi/Apps.Okapi.csproj
+++ b/Apps.Okapi/Apps.Okapi.csproj
@@ -4,12 +4,12 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Product>Okapi longhorn by terales2</Product>
+        <Product>Okapi longhorn</Product>
         <Description>Longhorn is a server application that allows you to execute Batch Configurations remotely on any set of input files. Batch Configurations which include pre-defined pipelines and filter configurations, can be exported from Rainbow.</Description>
         <Version>1.2.3</Version>
-        <PackageId>Apps.OkapiByTerales2</PackageId>
+        <PackageId>Apps.Okapi</PackageId>
         <RootNamespace>Apps.Okapi</RootNamespace>
-        <AssemblyName>Apps.OkapiByTerales2</AssemblyName>
+        <AssemblyName>Apps.Okapi</AssemblyName>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Apps.Okapi/Apps.Okapi.csproj
+++ b/Apps.Okapi/Apps.Okapi.csproj
@@ -4,12 +4,12 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Product>Okapi longhorn by terales</Product>
+        <Product>Okapi longhorn by terales2</Product>
         <Description>Longhorn is a server application that allows you to execute Batch Configurations remotely on any set of input files. Batch Configurations which include pre-defined pipelines and filter configurations, can be exported from Rainbow.</Description>
-        <Version>1.2.2</Version>
-        <PackageId>Apps.OkapiByTerales</PackageId>
+        <Version>1.2.3</Version>
+        <PackageId>Apps.OkapiByTerales2</PackageId>
         <RootNamespace>Apps.Okapi</RootNamespace>
-        <AssemblyName>Apps.OkapiByTerales</AssemblyName>
+        <AssemblyName>Apps.OkapiByTerales2</AssemblyName>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Apps.Okapi/Apps.Okapi.csproj
+++ b/Apps.Okapi/Apps.Okapi.csproj
@@ -4,12 +4,12 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Product>Okapi longhorn</Product>
+        <Product>Okapi longhorn by terales</Product>
         <Description>Longhorn is a server application that allows you to execute Batch Configurations remotely on any set of input files. Batch Configurations which include pre-defined pipelines and filter configurations, can be exported from Rainbow.</Description>
         <Version>1.2.2</Version>
-        <PackageId>Apps.Okapi</PackageId>
+        <PackageId>Apps.OkapiByTerales</PackageId>
         <RootNamespace>Apps.Okapi</RootNamespace>
-        <AssemblyName>Apps.Okapi</AssemblyName>
+        <AssemblyName>Apps.OkapiByTerales</AssemblyName>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Apps.Okapi/Invocables/AppInvocable.cs
+++ b/Apps.Okapi/Invocables/AppInvocable.cs
@@ -45,9 +45,12 @@ public class AppInvocable : BaseInvocable
         string endpoint = ApiEndpoints.Projects + $"/{projectId}" + ApiEndpoints.BatchConfiguration;
         var fileParam = FileParameter.Create("batchConfiguration", fileBytes, name, contentType);
 
-        try {
+        try
+        {
             var response = await Client.UploadFile(endpoint, Method.Post, fileParam, Creds);
-        } catch (PluginApplicationException e) {
+        }
+        catch (PluginApplicationException e)
+        {
             throw new PluginApplicationException("Could not upload your batch configuration file; " + e.Message);
         }
     }
@@ -64,9 +67,12 @@ public class AppInvocable : BaseInvocable
 
         var method = isZip ? Method.Post : Method.Put;
 
-        try {
+        try
+        {
             var response = await Client.UploadFile(endpoint, method, fileParam, Creds);
-        } catch (PluginApplicationException e) {
+        }
+        catch (PluginApplicationException e)
+        {
             throw new PluginApplicationException("Could not upload an input file; " + e.Message);
         }
     }

--- a/Apps.Okapi/Invocables/AppInvocable.cs
+++ b/Apps.Okapi/Invocables/AppInvocable.cs
@@ -43,18 +43,12 @@ public class AppInvocable : BaseInvocable
     protected async Task AddBatchConfig(string projectId, byte[] fileBytes, string name = "batch.bconf", string contentType = "application/octet-stream")
     {
         string endpoint = ApiEndpoints.Projects + $"/{projectId}" + ApiEndpoints.BatchConfiguration;
+        var fileParam = FileParameter.Create("batchConfiguration", fileBytes, name, contentType);
 
-        var baseUrl = Creds.Get(CredsNames.Url).Value;
-        var uploadFileRequest = new OkapiRequest(new OkapiRequestParameters
-        {
-            Method = Method.Post,
-            Url = baseUrl + endpoint
-        }).AddFile("batchConfiguration", fileBytes, name, contentType);
-
-        var response = await Client.ExecuteAsync(uploadFileRequest);
-        if (!response.IsSuccessStatusCode)
-        {
-            throw new PluginApplicationException($"Could not upload your batch configuration file; Code: {response.StatusCode}; Message: {response.Content}");
+        try {
+            var response = await Client.UploadFile(endpoint, Method.Post, fileParam, Creds);
+        } catch (PluginApplicationException e) {
+            throw new PluginApplicationException("Could not upload your batch configuration file; " + e.Message);
         }
     }
 
@@ -62,6 +56,7 @@ public class AppInvocable : BaseInvocable
     {
         if (string.IsNullOrEmpty(fileName)) throw new("File name is required.");
 
+        var fileParam = FileParameter.Create("inputFile", fileBytes, fileName, contentType);
         var isZip = fileName.EndsWith(".zip");
 
         var endpoint = ApiEndpoints.Projects + $"/{projectId}" + ApiEndpoints.InputFiles;
@@ -69,17 +64,10 @@ public class AppInvocable : BaseInvocable
 
         var method = isZip ? Method.Post : Method.Put;
 
-        var baseUrl = Creds.Get(CredsNames.Url).Value;
-        var uploadFileRequest = new OkapiRequest(new OkapiRequestParameters
-        {
-            Method = method,
-            Url = baseUrl + endpoint
-        }).AddFile("inputFile", fileBytes, fileName, contentType);
-
-        var response = await Client.ExecuteAsync(uploadFileRequest);
-        if (!response.IsSuccessStatusCode)
-        {
-            throw new PluginApplicationException($"Could not upload your file; Code: {response.StatusCode}; Message: {response.Content}");
+        try {
+            var response = await Client.UploadFile(endpoint, method, fileParam, Creds);
+        } catch (PluginApplicationException e) {
+            throw new PluginApplicationException("Could not upload an input file; " + e.Message);
         }
     }
 

--- a/Apps.Okapi/Invocables/AppInvocable.cs
+++ b/Apps.Okapi/Invocables/AppInvocable.cs
@@ -16,7 +16,7 @@ public class AppInvocable : BaseInvocable
         InvocationContext.AuthenticationCredentialsProviders.ToArray();
 
     protected OkapiClient Client { get; }
-    
+
     public AppInvocable(InvocationContext invocationContext) : base(invocationContext)
     {
         Client = new();
@@ -129,5 +129,5 @@ public class AppInvocable : BaseInvocable
         {
             throw new PluginApplicationException($"Status code: {response.StatusCode}, Content: {response.Content}");
         }
-    }    
+    }
 }

--- a/Tests.Okapi/Base/FileManagementClient.cs
+++ b/Tests.Okapi/Base/FileManagementClient.cs
@@ -1,0 +1,43 @@
+using Blackbird.Applications.Sdk.Common.Files;
+using Blackbird.Applications.SDK.Extensions.FileManagement.Interfaces;
+
+namespace Tests.Okapi.Base;
+
+public class FileManagementClient : IFileManagementClient
+{
+    private readonly string _folderLocation;
+
+    public FileManagementClient(string folderLocation)
+    {
+        _folderLocation = folderLocation ?? throw new ArgumentNullException(nameof(folderLocation));
+    }
+
+    public async Task<Stream> DownloadAsync(FileReference reference)
+    {
+        if (reference == null) throw new ArgumentNullException(nameof(reference));
+
+        var path = Path.Combine(_folderLocation, "Input", reference.Name);
+        var bytes = await File.ReadAllBytesAsync(path);
+
+        return new MemoryStream(bytes);
+    }
+
+    public async Task<FileReference> UploadAsync(Stream stream, string contentType, string fileName)
+    {
+        if (stream == null) throw new ArgumentNullException(nameof(stream));
+        if (string.IsNullOrEmpty(fileName)) throw new ArgumentNullException(nameof(fileName));
+
+        var path = Path.Combine(_folderLocation, "Output", fileName);
+        var directory = Path.GetDirectoryName(path);
+
+        if (!string.IsNullOrEmpty(directory))
+            Directory.CreateDirectory(directory);
+
+        using (var fileStream = File.Create(path))
+        {
+            await stream.CopyToAsync(fileStream);
+        }
+
+        return new FileReference { Name = fileName };
+    }
+}

--- a/Tests.Okapi/Base/TestBase.cs
+++ b/Tests.Okapi/Base/TestBase.cs
@@ -1,0 +1,43 @@
+using Blackbird.Applications.Sdk.Common.Authentication;
+using Blackbird.Applications.Sdk.Common.Invocation;
+using Microsoft.Extensions.Configuration;
+
+namespace Tests.Okapi.Base;
+
+public class TestBase
+{
+    public IEnumerable<AuthenticationCredentialsProvider> Creds { get; private set; }
+    public InvocationContext InvocationContext { get; private set; }
+    public FileManagementClient FileManagementClient { get; private set; }
+
+    public TestBase()
+    {
+        InitializeCredentials();
+        InitializeInvocationContext();
+        InitializeFileManager();
+    }
+
+    private void InitializeCredentials()
+    {
+        var config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
+        Creds = config.GetSection("ConnectionDefinition")
+                     .GetChildren()
+                     .Select(x => new AuthenticationCredentialsProvider(x.Key, x.Value))
+                     .ToList();
+    }
+
+    private void InitializeInvocationContext()
+    {
+        InvocationContext = new InvocationContext
+        {
+            AuthenticationCredentialsProviders = Creds
+        };
+    }
+
+    private void InitializeFileManager()
+    {
+        var config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
+        var folderLocation = config.GetSection("TestFolder").Value;
+        FileManagementClient = new FileManagementClient(folderLocation!);
+    }
+}

--- a/Tests.Okapi/CombinedActionsTests.cs
+++ b/Tests.Okapi/CombinedActionsTests.cs
@@ -1,0 +1,43 @@
+using Apps.Okapi.Actions;
+using Apps.Okapi.Models.Requests;
+using Blackbird.Applications.Sdk.Common.Files;
+using Tests.Okapi.Base;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Tests.Okapi;
+
+[TestClass]
+public class CombinedActionsTests : TestBase
+{
+    [TestMethod]
+    public async Task ConvertFileToXliff_ValidFile_ReturnsXliffAndPackage()
+    {
+        // given
+        var fileRequest = new UploadFileRequest
+        {
+            File = new FileReference
+            {
+                Name = "sample.html",
+                ContentType = "text/html"
+            }
+        };
+
+        var taskRequest = new ExecuteSingleLanguageTaskRequest
+        {
+            SourceLanguage = "en",
+            TargetLanguage = "es"
+        };
+
+        var conversionRequest = new FileConversionRequest
+        {
+            RemoveInappropriateCharactersInFileName = false
+        };
+
+        // when
+        var combinedActions = new CombinedActions(InvocationContext, FileManagementClient);
+        var result = await combinedActions.ConvertFileToXliff(fileRequest, taskRequest, conversionRequest);
+
+        // then
+        Assert.IsNotNull(result);
+    }
+}

--- a/Tests.Okapi/Input/sample.html
+++ b/Tests.Okapi/Input/sample.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Translation Extraction Smoke Test</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 40px;
+            line-height: 1.6;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Translation Extraction Test Page</h1>
+
+        <!-- Basic text elements -->
+        <div class="section">
+            <h2>Basic Text Elements</h2>
+            <p>This is a simple paragraph that should be translated. But it has two sentences.</p>
+            <p>This paragraph contains <strong>formatting</strong> and <em>styled text</em> that should be preserved.</p>
+            <p>This includes a <a href="#">link</a> that should be handled properly.</p>
+        </div>
+
+        <!-- Elements with attributes -->
+        <div class="section">
+            <h2>Elements with Attributes</h2>
+            <img src="placeholder.jpg" alt="This alt text should be translated">
+            <button title="This tooltip should be translated">Hover me</button>
+            <input type="text" placeholder="This placeholder should be translated">
+        </div>
+
+        <!-- Nested elements -->
+        <div class="section">
+            <h2>Nested Elements</h2>
+            <div>
+                <p>This is a <span>nested <em>content structure</em> with</span> multiple levels.</p>
+                <ul>
+                    <li>List item one</li>
+                    <li>List item <strong>two</strong></li>
+                    <li>List item <a href="#">three with link</a></li>
+                </ul>
+            </div>
+        </div>
+
+        <!-- Special content -->
+        <div class="section">
+            <h2>Special Content</h2>
+            <p>Text with special characters: &copy; &reg; &euro; &mdash;</p>
+            <p>Text with emoji: 🚀 🌍 🎉</p>
+            <pre>This is preformatted text
+                 that should maintain spacing</pre>
+        </div>
+
+        <div class="section">
+            <h2>Dynamic Content</h2>
+            <p>Hello, {username}! You have {count} new messages.</p>
+            <p>Your order #{orderId} will arrive on {deliveryDate}.</p>
+        </div>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const button = document.querySelector('button');
+            button.addEventListener('click', function() {
+                alert('Button clicked!');
+            });
+        });
+    </script>
+</body>
+</html>

--- a/Tests.Okapi/Tests.Okapi.csproj
+++ b/Tests.Okapi/Tests.Okapi.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Blackbird.Applications.Sdk.Common" Version="2.11.1" />
+    <PackageReference Include="Blackbird.Applications.SDK.Extensions.FileManagement" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Apps.Okapi\Apps.Okapi.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.json.example">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Output\" />
+  </ItemGroup>
+
+</Project>

--- a/Tests.Okapi/appsettings.json.example
+++ b/Tests.Okapi/appsettings.json.example
@@ -1,0 +1,6 @@
+{
+  "ConnectionDefinition": {
+    "url": "http://localhost:8080/okapi-longhorn/"
+  },
+  "TestFolder": "C:\\Users\\..."
+}

--- a/Tests.Okapi/appsettings.json.example
+++ b/Tests.Okapi/appsettings.json.example
@@ -2,5 +2,5 @@
   "ConnectionDefinition": {
     "url": "http://localhost:8080/okapi-longhorn/"
   },
-  "TestFolder": "C:\\Users\\..."
+  "TestFolder": "C:\\Users\\...\\Tests.Okapi"
 }


### PR DESCRIPTION
* Fixed an "Ambiguous URI empty segment" error that wasn't clear for users how to workaround.
  * The problem was that direct calls from `AppInvocable` weren't stripping the trailing slash like `OkapiClient` did.
  * I've fixed it by extracting file upload requests into a common method within `OkapiClient` instead of two direct calls from `AppInvocable`.
* Added a first integration test.
* Cleared up trailing whitespaces.