### PR TITLE
Introduce upload translation assets action

### DIFF
--- a/Apps.Okapi/Models/Requests/UploadTranslationAssetsRequest.cs
+++ b/Apps.Okapi/Models/Requests/UploadTranslationAssetsRequest.cs
@@ -1,0 +1,16 @@
+﻿using Blackbird.Applications.Sdk.Common;
+using Blackbird.Applications.Sdk.Common.Files;
+
+namespace Apps.Okapi.Models.Requests;
+
+public class UploadTranslationAssetsRequest
+{
+    [Display("OKAPI Longhorn working directory", Description = "Absolute path to the Okapi working directory, f.e.: /users/john/Okapi-Longhorn-Files/.")]
+    public string LonghornWorkDir { get; set; }
+
+    [Display("Translation memory (TMX file)")]
+    public FileReference Tmx { get; set; }
+
+    [Display("Segmentation rules (SRX file)", Description = "Upload custom segmentation rules.")]
+    public FileReference? Srx { get; set;}
+}

--- a/Apps.Okapi/Models/Responses/UploadTranslationAssetsResponse.cs
+++ b/Apps.Okapi/Models/Responses/UploadTranslationAssetsResponse.cs
@@ -1,0 +1,12 @@
+﻿using Blackbird.Applications.Sdk.Common;
+
+namespace Apps.Okapi.Models.Responses;
+
+public class UploadTranslationAssetsResponse
+{
+    [Display("Translation memory (TMX)")]
+    public string TMX { get; set; }
+
+    [Display("Translation memory (TMX)")]
+    public string? SRX { get; set; }
+}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Use the following actions to have full control of batchconfig executions on one 
 - **Create project**: Creates a new project within the system, returns the ID of the newly created project, and uploads a batch configuration file.
 - **Execute project** Executes the batch configuration on the uploaded input files, returns the output files
 
+### Pre-translate actions
+
+Use the following actions to reuse existing translations from translation memory (also known as "pre-translate"):
+
+- **Upload translation assets**: Uploads translation memory (TMX) and segmentation rules (SRX) to a new project, returns a path to files local to OKAPI server so these assets could be later linked in batch configurations.
+
 ## Example
 
 ![okapi-example-bird](image/README/okapi-example-bird.png)

--- a/Tests.Okapi/Base/TestBase.cs
+++ b/Tests.Okapi/Base/TestBase.cs
@@ -9,35 +9,24 @@ public class TestBase
     public IEnumerable<AuthenticationCredentialsProvider> Creds { get; private set; }
     public InvocationContext InvocationContext { get; private set; }
     public FileManagementClient FileManagementClient { get; private set; }
+    public string LonghornWorkDir { get; private set; }
 
     public TestBase()
     {
-        InitializeCredentials();
-        InitializeInvocationContext();
-        InitializeFileManager();
-    }
-
-    private void InitializeCredentials()
-    {
         var config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
+
         Creds = config.GetSection("ConnectionDefinition")
                      .GetChildren()
                      .Select(x => new AuthenticationCredentialsProvider(x.Key, x.Value))
                      .ToList();
-    }
 
-    private void InitializeInvocationContext()
-    {
         InvocationContext = new InvocationContext
         {
             AuthenticationCredentialsProviders = Creds
         };
-    }
 
-    private void InitializeFileManager()
-    {
-        var config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
-        var folderLocation = config.GetSection("TestFolder").Value;
-        FileManagementClient = new FileManagementClient(folderLocation!);
+        FileManagementClient = new FileManagementClient(config.GetSection("TestFolder").Value!);
+
+        LonghornWorkDir = config.GetSection("LonghornWorkDir").Value!;
     }
 }

--- a/Tests.Okapi/CombinedActionsTests.cs
+++ b/Tests.Okapi/CombinedActionsTests.cs
@@ -40,4 +40,91 @@ public class CombinedActionsTests : TestBase
         // then
         Assert.IsNotNull(result);
     }
+
+    [TestMethod]
+    public async Task UploadTranslationAssets_WithTmxAndSrx_ReturnsUploadedFileNames()
+    {
+        // given
+        var request = new UploadTranslationAssetsRequest
+        {
+            LonghornWorkDir = LonghornWorkDir,
+            Tmx = new FileReference
+            {
+                Name = "sample.tmx",
+                ContentType = "application/xml"
+            },
+            Srx = new FileReference
+            {
+                Name = "sample.srx",
+                ContentType = "application/xml"
+            }
+        };
+
+        // when
+        var combinedActions = new CombinedActions(InvocationContext, FileManagementClient);
+        var result = await combinedActions.UploadTranslationAssets(request);
+
+        // then
+        Assert.IsTrue(result.TMX.StartsWith(LonghornWorkDir));
+        Assert.IsTrue(result.TMX.EndsWith("/input/sample.tmx"));
+
+        Assert.IsTrue(result.SRX?.StartsWith(LonghornWorkDir));
+        Assert.IsTrue(result.SRX?.EndsWith("/input/sample.srx"));
+    }
+
+    [TestMethod]
+    public async Task UploadTranslationAssets_WithTmxAndSrxOnWindowsServer_ReturnsWindowsFilepaths()
+    {
+        // given
+        var fakeLonghornWorkDir = "C:\\Users\\TestUser\\Documents\\Okapi-Longhorn-Files";
+        var request = new UploadTranslationAssetsRequest
+        {
+            LonghornWorkDir = fakeLonghornWorkDir,
+            Tmx = new FileReference
+            {
+                Name = "sample.tmx",
+                ContentType = "application/xml"
+            },
+            Srx = new FileReference
+            {
+                Name = "sample.srx",
+                ContentType = "application/xml"
+            }
+        };
+
+        // when
+        var combinedActions = new CombinedActions(InvocationContext, FileManagementClient);
+        var result = await combinedActions.UploadTranslationAssets(request);
+
+        // then
+        Assert.IsTrue(result.TMX.StartsWith(fakeLonghornWorkDir));
+        Assert.IsTrue(result.TMX.EndsWith("\\input\\sample.tmx"));
+
+        Assert.IsTrue(result.SRX?.StartsWith(fakeLonghornWorkDir));
+        Assert.IsTrue(result.SRX?.EndsWith("\\input\\sample.srx"));
+    }
+
+    [TestMethod]
+    public async Task UploadTranslationAssets_WithOnlyTmx_ReturnsUploadedFileName()
+    {
+        // given
+        var request = new UploadTranslationAssetsRequest
+        {
+            LonghornWorkDir = LonghornWorkDir,
+            Tmx = new FileReference
+            {
+                Name = "sample.tmx",
+                ContentType = "application/xml"
+            }
+        };
+
+        // when
+        var combinedActions = new CombinedActions(InvocationContext, FileManagementClient);
+        var result = await combinedActions.UploadTranslationAssets(request);
+
+        // then
+        Assert.IsTrue(result.TMX.StartsWith(LonghornWorkDir));
+        Assert.IsTrue(result.TMX.EndsWith("/input/sample.tmx"));
+        Assert.IsNull(result.SRX);
+    }
 }

--- a/Tests.Okapi/Input/sample.srx
+++ b/Tests.Okapi/Input/sample.srx
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<srx xmlns="http://www.lisa.org/srx20" version="2.0">
+    <header>
+        <segmentsubflows>false</segmentsubflows>
+        <cascade>no</cascade>
+    </header>
+    <body>
+        <languagerules>
+            <languagerule languagerulename="Default">
+                <rule>
+                    <beforebreak>\.</beforebreak>
+                    <afterbreak>\s</afterbreak>
+                </rule>
+            </languagerule>
+        </languagerules>
+        <maprules>
+            <languagemap languagepattern=".*" languagerulename="Default"/>
+        </maprules>
+    </body>
+</srx>

--- a/Tests.Okapi/Input/sample.tmx
+++ b/Tests.Okapi/Input/sample.tmx
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE tmx SYSTEM "tmx14.dtd">
+<tmx version="1.4">
+  <header
+    creationtool="AI Assistant"
+    creationtoolversion="1.0"
+    segtype="sentence"
+    o-tmf="XML"
+    adminlang="en"
+    srclang="en"
+    datatype="plaintext"
+    creationdate="20240514T120000Z">
+  </header>
+  <body>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Welcome to our new product launch event.</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Bienvenidos a nuestro evento de lanzamiento de producto.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Please contact customer support if you need assistance.</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Por favor, contacte con atención al cliente si necesita ayuda.</seg>
+      </tuv>
+    </tu>
+  </body>
+</tmx>

--- a/Tests.Okapi/appsettings.json.example
+++ b/Tests.Okapi/appsettings.json.example
@@ -2,5 +2,6 @@
   "ConnectionDefinition": {
     "url": "http://localhost:8080/okapi-longhorn/"
   },
-  "TestFolder": "C:\\Users\\...\\Tests.Okapi"
+  "TestFolder": "C:\\Users\\...\\Tests.Okapi",
+  "LonghornWorkDir": "C:\\Users\\...\\Okapi-Longhorn-Files"
 }


### PR DESCRIPTION
This PR introduces a new action.

The action:
- uploads translation memory (TMX) and segmentation rules (SRX) to a new project,
- returns a path to files local to OKAPI server so these assets could be later linked in batch configurations.

This action can be already used by customers with an advanced OKAPI know how and another action is planned, so that translation assets could be used without an advanced Bird setup.

I'm splitting the PRs, so they would be easier to review, make sense of and provide a feedback.

@vitalii-bezuhlyi can you review, please?